### PR TITLE
Implement i18n Support & Add zh-TW

### DIFF
--- a/app/src/main/java/com/dar/nclientv2/MainActivity.java
+++ b/app/src/main/java/com/dar/nclientv2/MainActivity.java
@@ -752,7 +752,7 @@ public class MainActivity extends BaseActivity
                 .setNegativeButton(R.string.cancel,null)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     for(GenericGallery g:inspector.getGalleries())
-                        DownloadGalleryV2.downloadGallery(MainActivity.this, (SimpleGallery)g);
+                        DownloadGalleryV2.downloadGallery(MainActivity.this, g);
                 });
         builder.show();
     }

--- a/app/src/main/java/com/dar/nclientv2/components/status/Status.java
+++ b/app/src/main/java/com/dar/nclientv2/components/status/Status.java
@@ -7,7 +7,7 @@ public class Status {
     public final String name;
 
     Status(int color, String name) {
-        this.color = Color.argb(0x7f,Color.red(color),Color.green(color),Color.blue(color));;
+        this.color = Color.argb(0x7f,Color.red(color),Color.green(color),Color.blue(color));
         this.name = name;
     }
     public int opaqueColor(){

--- a/app/src/main/java/com/dar/nclientv2/settings/Global.java
+++ b/app/src/main/java/com/dar/nclientv2/settings/Global.java
@@ -345,10 +345,40 @@ public class Global {
         if(client!=null)return;
         reloadHttpClient(context);
     }
-    public static Locale initLanguage(Context context){
-        String x=context.getSharedPreferences("Settings",0).getString(context.getString(R.string.key_language),"en");
-        assert x != null;
-        return new Locale(x);
+
+    public static Locale initLanguage(Context context) {
+        SharedPreferences sharedPreferences = context.getSharedPreferences("Settings", 0);
+        String prefLangKey = context.getString(R.string.key_language);
+        String defaultValue = context.getString(R.string.key_default_value);
+        String langCode = sharedPreferences.getString(prefLangKey, defaultValue);
+        assert langCode != null;
+        if (langCode.equalsIgnoreCase(defaultValue)){
+            Locale defaultLocale = Locale.getDefault();
+            if (isLocaleAvailable(context, defaultLocale)) return defaultLocale;
+        }
+        if (langCode.contains("-")) {
+            String[] regexSplit = langCode.split("-");
+            Locale targetLocale = new Locale(regexSplit[0], regexSplit[1]);
+            if (isLocaleAvailable(context, targetLocale)) return targetLocale;
+        }
+        return new Locale("en", "US");
+    }
+
+    private static boolean isLocaleAvailable(Context context, Locale targetLocale) {
+        Locale[] availableLocales = Locale.getAvailableLocales();
+        String[] supportedLangCodes = context.getResources().getStringArray(R.array.language_data);
+        // array.stream is not supported on Android <6.0
+        for (Locale availableLocale : availableLocales)
+            if (availableLocale.getCountry().equalsIgnoreCase(targetLocale.getCountry()) &&
+                    availableLocale.getLanguage().equalsIgnoreCase(targetLocale.getLanguage()))
+                for (String supportedLangCode : supportedLangCodes)
+                    if (getLocaleCode(targetLocale).equalsIgnoreCase(supportedLangCode))
+                        return true;
+        return false;
+    }
+
+    private static String getLocaleCode(Locale locale) {
+        return String.format("%s-%s", locale.getLanguage(), locale.getCountry());
     }
     private static ThemeScheme initTheme(Context context){
         String h=context.getSharedPreferences("Settings",0).getString(context.getString(R.string.key_theme_select),"dark");

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -2,20 +2,14 @@
 <resources>
     <string name="setting_on_ignore_tags">Other tags won\'t be queried when a tag is selected from the gallery menu (except language)</string>
     <string name="setting_off_ignore_tags">Other tags will be queried when a tag is selected from the gallery menu</string>
-    <string name="setting_on_high_res">Best resolution images will be loaded (more data)</string>
-    <string name="setting_off_high_res">Thumbnails images will be loaded (less data)</string>
-    <string name="setting_on_load">Images will be loaded in all activities</string>
-    <string name="setting_off_load">Images will be loaded only in single page viewer</string>
     <string name="setting_on_use_account_tag">Use the account tags into the search query (Local tags will have priority)</string>
     <string name="setting_off_use_account_tag">Account tags will be ignored for the query</string>
     <string name="theme_summary">Select theme colors</string>
     <string name="send_crash_report">Send crash report</string>
     <string name="change_theme">Change theme</string>
     <string name="clear_cache">Clear cache</string>
-    <string name="load_images">Load images</string>
     <string name="infinite_scroll">Infinite scroll</string>
     <string name="ignore_tags">Ignore other tags</string>
-    <string name="high_res_gallery">Load image in best resolution into gallery</string>
     <string name="use_account_tag">Use tags from account</string>
     <string name="title_activity_gallery">Gallery</string>
     <string name="title_activity_zoom">Zoom Activity</string>
@@ -43,14 +37,9 @@
     <string name="only_japanese">Only japanese</string>
     <string name="only_chinese">Only chinese</string>
     <string name="all_languages">All languages</string>
-    <string name="username_or_email">Username or Email</string>
-    <string name="password">Password</string>
     <string name="login">Log in</string>
     <string name="login_formatted" formatted="true">Logged as %s</string>
     <string name="logout">Logout</string>
-    <string name="forgot_password">Forgot your password? <b>Reset it</b></string>
-    <string name="register">Don\'t have an account? <b>Register</b></string>
-    <string name="invalid_credentials">Invalid credentials</string>
     <string name="favorite_online_manga">Favorite online manga</string>
     <string name="online_tags">Online tags</string>
     <string name="add_to_online_favorite">Add to online favorites</string>
@@ -82,7 +71,6 @@
     <string name="next_page">Next page</string>
     <string name="downloaded_manga">Downloaded manga</string>
     <string name="download_gallery">Download gallery</string>
-    <string name="download_completed">Download completed</string>
     <string name="delete_gallery_size_format" formatted="true">Delete gallery (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">Do you want to delete the gallery:\n%s</string>
     <string name="share_with">Share with</string>
@@ -189,7 +177,6 @@
     <string name="column_count_select">Column count select</string>
     <string name="send_with_title">Send with title?</string>
     <string name="caption_send_with_title">Append url to the image as caption to the image?</string>
-    <string name="error_404">Error 404: not found</string>
     <string name="history_size">History size</string>
     <string name="history_size_summary">Set the max number of entries for the history</string>
     <string name="view_history">View history</string>
@@ -197,7 +184,6 @@
     <string name="clear_history">Clear history</string>
     <string name="cancelled_format">Cancelled: %s</string>
     <string name="completed_format">Completed: %s</string>
-    <string name="stop">Stop</string>
     <string name="downloading_format">Downloading: %s</string>
     <string name="toggle_favorite">Toggle favorite</string>
     <string name="resume">Resume</string>
@@ -235,13 +221,11 @@
     <string name="sort_type_title_format" formatted="true">Choose sort type (%s)</string>
     <string name="sort_select_type">Choose sort type:</string>
     <string name="unable_to_connect_to_the_site">Unable to connect to the site</string>
-    <string name="error">Error</string>
     <string name="no_entry_found">No entries found</string>
     <string name="retry">Retry</string>
     <string name="folder_location">Folder location</string>
     <string name="default_zoom">Default zoom</string>
     <string name="choose_directory">Choose directory</string>
-    <string name="change_directory_position">Change directory position</string>
     <string name="bookmark_here">Bookmark here</string>
     <string name="resume_from_page">Resume from page %d</string>
     <string name="new_beta_version_found">New beta version found</string>

--- a/app/src/main/res/values-ar-rSA/strings.xml
+++ b/app/src/main/res/values-ar-rSA/strings.xml
@@ -273,6 +273,7 @@
     <string name="status_viewer">Status viewer</string>
 
     <string-array name="language">
+        <item>System Default</item>
         <item>English</item>
         <item>Chinese (Traditional)</item>
         <item>Chinese (Simplified)</item>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -5,10 +5,6 @@
     <!--SUMMARY-->
     <string name="setting_on_ignore_tags">Andere Tags werden nicht gesucht wenn du einen Tag von einer Galerie auswählst (außer die Sprache)</string>
     <string name="setting_off_ignore_tags">Andere Tags werden gesucht wenn du einen Tag von einer Galerie auswählst</string>
-    <string name="setting_on_high_res">Hochauflösende Bilder werden geladen (verbraucht mehr Daten)</string>
-    <string name="setting_off_high_res">Vorschaubilder werden geladen (verbraucht weniger Daten)</string>
-    <string name="setting_on_load">Bilder werden überall geladen</string>
-    <string name="setting_off_load">Bilder werden nur im Einzelseitenbetrachter geladen</string>
     <string name="setting_on_use_account_tag">Benutze online Tags in deiner Suche (lokale Tags haben Priorität)</string>
     <string name="setting_off_use_account_tag">Online Tags werden bei deiner Suche ignoriert</string>
     <string name="theme_summary">Wähle Farbschema</string>
@@ -17,10 +13,8 @@
     <string name="send_crash_report">Sende Absturzbericht</string>
     <string name="change_theme">Ändere Thema</string>
     <string name="clear_cache">Lösche den Cache</string>
-    <string name="load_images">Lade Bilder</string>
     <string name="infinite_scroll">Unendlich scrollen</string>
     <string name="ignore_tags">Ignoriere andere Tags</string>
-    <string name="high_res_gallery">Lade Bilder in bester qualität</string>
     <string name="use_account_tag">Benutze Account Tags</string>
 
     <string name="title_activity_gallery">Galerie</string>
@@ -56,14 +50,9 @@
     <string name="all_languages">Alle Sprachen</string>
 
 
-    <string name="username_or_email">Benutzername oder Email</string>
-    <string name="password">Passwort</string>
     <string name="login">Einloggen</string>
     <string name="login_formatted" formatted="true">Eingeloggt als %s</string>
     <string name="logout">Ausloggen</string>
-    <string name="forgot_password">Passwort vergessen? <b>Zurücksetzen</b></string>
-    <string name="register">Du hast keinen Account? <b>Registrieren</b></string>
-    <string name="invalid_credentials">Ungültige Anmeldedaten</string>
 
     <string name="favorite_online_manga">Online Manga Favoriten</string>
     <string name="online_tags">Online Tag</string>
@@ -102,7 +91,6 @@
 
     <string name="downloaded_manga">Heruntergeladene Manga</string>
     <string name="download_gallery">Galerie herunterladen</string>
-    <string name="download_completed">Download komplett</string>
 
     <string name="delete_gallery_size_format" formatted="true">Lösche Galerie (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">Möchtest du die Galerie löschen:\n%s</string>
@@ -214,7 +202,6 @@
     <string name="column_count_select">Spaltenanzahl auswählen</string>
     <string name="send_with_title">Mit Titel senden?</string>
     <string name="caption_send_with_title">URL als Beschreibung zum Bild hinzufügen?</string>
-    <string name="error_404">Fehler 404: nicht gefunden</string>
     <string name="history_size">Verlauf Größe</string>
     <string name="history_size_summary">Setze die maximale Anzahl an Einträgen für deinen Verlauf</string>
     <string name="view_history">Verlauf anschauen</string>
@@ -222,7 +209,6 @@
     <string name="clear_history">Verlauf löschen</string>
     <string name="cancelled_format">Abgebrochen: %s</string>
     <string name="completed_format">Fertiggestellt: %s</string>
-    <string name="stop">Stop</string>
     <string name="downloading_format">Lade: %s</string>
     <string name="toggle_favorite">Favoriten umschalten</string>
     <string name="resume">Fortsetzen</string>
@@ -259,13 +245,11 @@
     <string name="sort_type_title_format" formatted="true">Wähle Sortiertyp (%s)</string>
     <string name="sort_select_type">Wähle Sortiertyp:</string>
     <string name="unable_to_connect_to_the_site">Kann sich nicht mit der Seite verbinden</string>
-    <string name="error">Fehler</string>
     <string name="no_entry_found">Kein Eintrag gefunden</string>
     <string name="retry">Wiederholen</string>
     <string name="folder_location">Ordner Location</string>
     <string name="default_zoom">Standard Zoom</string>
     <string name="choose_directory">Ordner auswählen</string>
-    <string name="change_directory_position">Ordner position ändern</string>
     <string name="bookmark_here">Lesezeichen hier</string>
     <string name="resume_from_page">Mit Seite %d fortsetzen</string>
     <string name="new_beta_version_found">Neue Beta Version gefunden</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -296,6 +296,7 @@
     <string name="status_column_count">Select status column count</string>
     <string name="status_viewer">Status viewer</string>
     <string-array name="language">
+        <item>System Default</item>
         <item>Englisch</item>
         <item>Chinesisch (Traditionell)</item>
         <item>Chinesisch (Vereinfacht)</item>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -295,6 +295,7 @@
     <string name="status_column_count">Select status column count</string>
     <string name="status_viewer">Status viewer</string>
     <string-array name="language">
+        <item>System Default</item>
         <item>Inglese</item>
         <item>Cinese (Tradizionale)</item>
         <item>Cinese (Semplificate)</item>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -4,10 +4,6 @@
     <!--SUMMARY-->
     <string name="setting_on_ignore_tags">Non verranno aggiunti ulteriori tag quando un tag è scelto da una galleria (tranne la lingua)</string>
     <string name="setting_off_ignore_tags">Verranno aggiunti ulteriori tag quando un tag è scelto da una galleria (tranne la lingua)</string>
-    <string name="setting_on_high_res">Verrà usata la massima risuluzione per le immagini (più dari)</string>
-    <string name="setting_off_high_res">Verrà usata la miniatura per le immagini (meno dati)</string>
-    <string name="setting_on_load">Le immagini verranno caricate ovunque</string>
-    <string name="setting_off_load">Le immagini verranno caricate solo nella visualizzazione a singola pagina</string>
     <string name="setting_on_use_account_tag">Usa i tag online per la ricerca (i tag locali avranno priorità)</string>
     <string name="setting_off_use_account_tag">I tag online verranno ignorati</string>
     <string name="theme_summary">Seleziona schema colori</string>
@@ -16,10 +12,8 @@
     <string name="send_crash_report">Invia report in caso di errori</string>
     <string name="change_theme">Cambia temi</string>
     <string name="clear_cache">Pulisci cache</string>
-    <string name="load_images">Carica immagini</string>
     <string name="infinite_scroll">Scorrimento infinito</string>
     <string name="ignore_tags">Ignora altri tag</string>
-    <string name="high_res_gallery">Carica immagini ad alta risoluzione</string>
     <string name="use_account_tag">Usa i tag dall\'account</string>
 
     <string name="title_activity_gallery">Galleria</string>
@@ -55,14 +49,9 @@
     <string name="all_languages">Tutte le lingue</string>
 
 
-    <string name="username_or_email">Username o Email</string>
-    <string name="password">Password</string>
     <string name="login">Accedi</string>
     <string name="login_formatted" formatted="true">Entrato come %s</string>
     <string name="logout">Logout</string>
-    <string name="forgot_password">Password dimenticata? <b>Reimpostala</b></string>
-    <string name="register">Non hai un account? <b>Registrati</b></string>
-    <string name="invalid_credentials">Credenziali invalide</string>
 
     <string name="favorite_online_manga">Manga online preferiti</string>
     <string name="online_tags">Online tag</string>
@@ -101,7 +90,6 @@
 
     <string name="downloaded_manga">Manga scaricati</string>
     <string name="download_gallery">Scarica galleria</string>
-    <string name="download_completed">Download completato</string>
 
     <string name="delete_gallery_size_format" formatted="true">Cancella galleria (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">Vuoi cancellare la gallerria:\n%s</string>
@@ -213,7 +201,6 @@
     <string name="column_count_select">Seleziona numero colonne</string>
     <string name="send_with_title">Invia con titolo?</string>
     <string name="caption_send_with_title">Inserire URL come descrizione dell\'immagine?</string>
-    <string name="error_404">Errore 404: non trovato</string>
     <string name="history_size">Grandezza cronologia</string>
     <string name="history_size_summary">Seleziona numero massimo di elementi nella cronologia</string>
     <string name="view_history">Vedi cronologia</string>
@@ -221,7 +208,6 @@
     <string name="clear_history">Pulisci cronologia</string>
     <string name="cancelled_format">Cancellato: %s</string>
     <string name="completed_format">Completato: %s</string>
-    <string name="stop">Ferma</string>
     <string name="downloading_format">Scaricando: %s</string>
     <string name="toggle_favorite">Alterna preferito</string>
     <string name="resume">Riprendi</string>
@@ -258,13 +244,11 @@
     <string name="sort_type_title_format" formatted="true">Scegli tipo ordinamento (%s)</string>
     <string name="sort_select_type">Seleziona tipo di ordinamento:</string>
     <string name="unable_to_connect_to_the_site">Impossibile connettersi al sito</string>
-    <string name="error">Errore</string>
     <string name="no_entry_found">Nessuna galleria trovata</string>
     <string name="retry">Riprova</string>
     <string name="folder_location">Posizione cartella</string>
     <string name="default_zoom">Default zoom</string>
     <string name="choose_directory">Scegli cartella</string>
-    <string name="change_directory_position">Scegli posizione cartella</string>
     <string name="bookmark_here">Segnalibro qui</string>
     <string name="resume_from_page">Ricomincia dalla pagina %d</string>
     <string name="new_beta_version_found">Nuova versione beta trovata</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -215,6 +215,7 @@
     <string name="rotate_image">Fotoğrafı çevir</string>
 
     <string-array name="language">
+        <item>System Default</item>
         <item>İngilizce</item>
         <item>Çince (Geleneksel)</item>
         <item>Çince (Basitleştirilmiş)</item>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -4,8 +4,6 @@
     <!--SUMMARY-->
     <string name="setting_on_ignore_tags">Diğer etiketler manga menüsünden bir etiket seçildiğinde listelenmeyecek (dil hariç)</string>
     <string name="setting_off_ignore_tags">Diğer etiketler manga menüsünden bir etiket seçildiğinde listelenecek</string>
-    <string name="setting_on_high_res">Kullanılabilen en yüksek çözünürlük yüklenecek (daha fazla veri gerektirir)</string>
-    <string name="setting_off_load">Fotoğraflar sadece tek sayfa görünümünde yüklenecek</string>
     <string name="setting_off_use_account_tag">Hesap etiketleri aramada dikkate alınmayacak</string>
     <string name="theme_summary">Tema rengini seç</string>
 
@@ -13,7 +11,6 @@
     <string name="send_crash_report">Otomatik çökme raporu gönder</string>
     <string name="change_theme">Tema değiştir</string>
     <string name="clear_cache">Önbelleği temizle</string>
-    <string name="load_images">Fotoğrafları yükle</string>
     <string name="infinite_scroll">Sonsuz kaydırma</string>
     <string name="use_account_tag">Hesaptan etiketleri kullan</string> <!-- DEPRECATED-->
 
@@ -49,12 +46,9 @@
     <string name="only_chinese">Sadece Çince</string>
     <string name="all_languages">Tüm Diller</string>
 
-    <string name="username_or_email">Kullanıcı adı ve ya Email</string>
     <string name="login">Giriş yap</string>
     <string name="login_formatted" formatted="true">%s olarak giriş yapıldı</string>
     <string name="logout">Çıkış yap</string>
-    <string name="forgot_password">Şifrenizi mi unuttunuz? <b>Sıfırlayın</b></string>
-    <string name="register">Hesabınız yok mu? <b>Kaydol</b></string>
 
     <string name="favorite_online_manga">Favori online manga</string>
     <string name="online_tags">Online etiketler</string>
@@ -91,7 +85,6 @@
 
     <string name="downloaded_manga">İndirilmiş Mangalar</string>
     <string name="download_gallery">Bu mangayı indir</string>
-    <string name="download_completed">İndirme tamamlandı</string>
 
     <string name="delete_gallery_size_format" formatted="true">Mangayı sil %.2fMB boyutunda</string> <!--Delete manga? Its xMB-->
     <string name="delete_gallery_format" formatted="true">Bu mangayı silmek istiyor musunuz? %s</string> 
@@ -192,7 +185,6 @@
     <string name="column_count_select">Sütun sayısı seç</string>
     <string name="send_with_title">Başlıkla gönder?</string>
     <string name="caption_send_with_title">Fotoğrafa URL yi çeviri olarak ekle?</string>
-    <string name="error_404">Hata 404: Bulunamadı</string>
     <string name="history_size">Geçmiş boyutu</string>
     <string name="history_size_summary">Geçmişe kaydedilecek kayıt sayısını seç</string>
     <string name="view_history">Geçmişi görüntüle</string>
@@ -200,7 +192,6 @@
     <string name="clear_history">Geçmişi temizle</string>
     <string name="cancelled_format">İptal edildi: %s</string>
     <string name="completed_format">İndirme tamamlandı: %s</string>
-    <string name="stop">Dur</string>
     <string name="downloading_format">İndiriliyor: %s</string>
     <string name="toggle_favorite">Favorilere ekle/çıkar</string>
     <string name="resume">Devam et</string>
@@ -234,13 +225,8 @@
         <item>Japonca</item>
         <item>Özel</item>
     </string-array>
-    <string name="setting_off_high_res">Önizlemeler yüklenecek (az veri kullanır)</string>
-    <string name="setting_on_load">Fotoğraflar tüm aktivitelerde yüklenecek</string>
     <string name="setting_on_use_account_tag">Hesap etiketlerini aramada kullan (Yerel etiketler daha önceliklidir)</string>
     <string name="ignore_tags">Diğer etiketleri dikkate alma</string>
-    <string name="high_res_gallery">Fotoğrafı mangada en yüksek çözünürlükte yükle</string>
-    <string name="password">Şifre</string>
-    <string name="invalid_credentials">Yanlış giriş bilgisi. Lütfen İsminizi ve ya Şifrenizi tekrar girin</string>
     <string name="created_pdf">PDF başarıyla oluşturuldu</string>
     <string name="navigation_drawer_open">Gezinme çekmecesini aç</string>
     <string name="link_copied_to_clipboard">Link panoya kopyalandı</string>
@@ -279,13 +265,11 @@
     <string name="sort_select_type">Sıralama tipi seç:</string>
     <string name="sort_type_title_format" formatted="true">Sıralama tipi seç (%s)</string>
     <string name="unable_to_connect_to_the_site">Siteye bağlanılamadı</string>
-    <string name="error">Hata</string>
     <string name="no_entry_found">Herhangi bir sonuç bulunamadı</string>
     <string name="retry">Yeniden Dene</string>
     <string name="folder_location">İndirme Dizini</string>
     <string name="default_zoom">Varsayılan Yakınlaştırma</string>
     <string name="choose_directory">Dizin Seç</string>
-    <string name="change_directory_position">Dizin konumunu değiştir</string>
     <string name="bookmark_here">Buraya yer işareti ekle</string>
     <string name="resume_from_page">%d. sayfadan devam et</string>
     <string name="new_beta_version_found">Yeni beta sürümü bulundu</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--Thanks to ZerOri and linsui for the Simplified Chinese translation-->
 <resources>
-
-
     <string name="setting_on_ignore_tags">从画廊菜单中选中一个标签时不再查询其它标签（语言项除外）</string>
     <string name="setting_off_ignore_tags">从画廊菜单中选中一个标签时查询其它标签</string>
     <string name="setting_on_high_res">加载原图（较多流量）</string>
@@ -276,12 +274,13 @@
     <string name="status_viewer">状态查看器</string>
 
     <string-array name="language">
+        <item>默认</item>
         <item>英文</item>
         <item>中文（繁体）</item>
         <item>中文（简体）</item>
         <item>土耳其语</item>
         <item>意大利语</item>
-	<item>德语</item>
+	    <item>德语</item>
         <item>阿拉伯语</item>
     </string-array>
     <string-array name="theme">

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -3,20 +3,14 @@
 <resources>
     <string name="setting_on_ignore_tags">从画廊菜单中选中一个标签时不再查询其它标签（语言项除外）</string>
     <string name="setting_off_ignore_tags">从画廊菜单中选中一个标签时查询其它标签</string>
-    <string name="setting_on_high_res">加载原图（较多流量）</string>
-    <string name="setting_off_high_res">加载缩略图（较少流量）</string>
-    <string name="setting_on_load">所有活动均加载图像</string>
-    <string name="setting_off_load">仅单页阅读时加载图像</string>
     <string name="setting_on_use_account_tag">在搜索请求中使用账户标签（本地标签优先）</string>
     <string name="setting_off_use_account_tag">在搜索请求中忽略账户标签</string>
     <string name="theme_summary">选择主题颜色</string>
     <string name="send_crash_report">发送崩溃报告</string>
     <string name="change_theme">更改主题</string>
     <string name="clear_cache">清除缓存</string>
-    <string name="load_images">加载图像</string>
     <string name="infinite_scroll">无限滚动</string>
     <string name="ignore_tags">忽略其它标签</string>
-    <string name="high_res_gallery">以最佳分辨率加载画廊图像</string>
     <string name="use_account_tag">使用账户标签</string>
     <string name="title_activity_gallery">画廊</string>
     <string name="title_activity_zoom">启用放大</string>
@@ -44,14 +38,9 @@
     <string name="only_japanese">仅日文</string>
     <string name="only_chinese">仅中文</string>
     <string name="all_languages">所有语言</string>
-    <string name="username_or_email">用户名或邮件</string>
-    <string name="password">密码</string>
     <string name="login">登录</string>
     <string name="login_formatted" formatted="true">以 %s 身份登录</string>
     <string name="logout">登出</string>
-    <string name="forgot_password">忘记密码？<b>重置密码</b></string>
-    <string name="register">没有账户？<b>注册账号</b></string>
-    <string name="invalid_credentials">无效凭证</string>
     <string name="favorite_online_manga">在线收藏漫画</string>
     <string name="online_tags">在线标签</string>
     <string name="add_to_online_favorite">添加至在线收藏</string>
@@ -83,7 +72,6 @@
     <string name="next_page">下一页</string>
     <string name="downloaded_manga">已下载漫画</string>
     <string name="download_gallery">下载画廊</string>
-    <string name="download_completed">下载完成</string>
     <string name="delete_gallery_size_format" formatted="true">删除画廊 (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">是否删除画廊：\n%s</string>
     <string name="share_with">分享</string>
@@ -189,7 +177,6 @@
     <string name="column_count_select">列数选择</string>
     <string name="send_with_title">与标题一起发送？</string>
     <string name="caption_send_with_title">在图片上添加 URL 水印？</string>
-    <string name="error_404">错误 404: 未找到</string>
     <string name="history_size">历史条目数</string>
     <string name="history_size_summary">设置历史条目最大值</string>
     <string name="view_history">阅读历史</string>
@@ -198,7 +185,6 @@
     <string name="clear_history">清除历史</string>
     <string name="cancelled_format">取消: %s</string>
     <string name="completed_format">完成: %s</string>
-    <string name="stop">停止</string>
     <string name="downloading_format">下载中: %s</string>
     <string name="toggle_favorite">切换收藏</string>
     <string name="resume">恢复</string>
@@ -236,13 +222,11 @@
     <string name="sort_select_type">选择排序类型：</string>
     <string name="sort_type_title_format" formatted="true">选择排序类型（%s）</string>
     <string name="unable_to_connect_to_the_site">无法连接站点</string>
-    <string name="error">错误</string>
     <string name="no_entry_found">找不到条目</string>
     <string name="retry">重试</string>
     <string name="folder_location">文件夹位置</string>
     <string name="default_zoom">默认缩放</string>
     <string name="choose_directory">选择文件夹</string>
-    <string name="change_directory_position">选择文件夹位置</string>
     <string name="bookmark_here">加入书签</string>
     <string name="resume_from_page">从 %d 页继续</string>
     <string name="new_beta_version_found">发现新的测试版</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--Thanks to ZerOri for the Traditional Chinese translation-->
+<!--Thanks to ZerOri & Still34 for the Traditional Chinese translation-->
 <resources>
     <!--SUMMARY-->
-    <string name="setting_on_ignore_tags">從畫廊功能表中選中一個標籤時不再查詢其它標籤（語言項除外）</string>
-    <string name="setting_off_ignore_tags">從畫廊功能表中選中一個標籤時查詢其它標籤</string>
+    <string name="setting_on_ignore_tags">從圖庫功能表中選中一個標籤時不再查詢其它標籤（語言項除外）</string>
+    <string name="setting_off_ignore_tags">從圖庫功能表中選中一個標籤時查詢其它標籤</string>
     <string name="setting_on_high_res">載入原圖（更多資料量）</string>
-    <string name="setting_off_high_res">載入縮略圖（較少資料量）</string>
+    <string name="setting_off_high_res">載入縮圖（較少資料量）</string>
     <string name="setting_on_load">所有活動均載入圖像</string>
     <string name="setting_off_load">僅單頁閱讀時載入圖像</string>
-    <string name="setting_on_use_account_tag">帳戶標籤用於搜查（本地標籤優先）</string>
-    <string name="setting_off_use_account_tag">搜查時忽略帳戶標籤</string>
+    <string name="setting_on_use_account_tag">帳戶標籤用於搜尋（本地標籤優先）</string>
+    <string name="setting_off_use_account_tag">搜尋時忽略帳戶標籤</string>
     <string name="theme_summary">選擇主題顏色</string>
 
     <!--SETTINGS NAME-->
-    <string name="send_crash_report">發送崩潰報告</string>
+    <string name="send_crash_report">發送錯誤報告</string>
     <string name="change_theme">更改主題</string>
-    <string name="clear_cache">清除緩存</string>
+    <string name="clear_cache">清除快取</string>
     <string name="load_images">載入圖像</string>
     <string name="infinite_scroll">無限滾動</string>
     <string name="ignore_tags">忽略其它標籤</string>
-    <string name="high_res_gallery">以最佳解析度載入畫廊圖像</string>
+    <string name="high_res_gallery">以最佳解析度載入圖庫圖像</string>
     <string name="use_account_tag">使用帳戶標籤</string>
 
-    <string name="title_activity_gallery">畫廊</string>
-    <string name="title_activity_zoom">啟用放大</string>
+    <string name="title_activity_gallery">圖庫</string>
+    <string name="title_activity_zoom">啟用縮放</string>
     <string name="title_activity_tag_filter">標籤篩選</string>
-    <string name="title_activity_login">登錄</string>
+    <string name="title_activity_login">登入</string>
 
     <string name="parodies">原作</string>
     <string name="characters">角色</string>
     <string name="tags">標籤</string>
-    <string name="artists">藝術家</string>
+    <string name="artists">繪師</string>
     <string name="groups">社團</string>
     <string name="languages">語言</string>
     <string name="categories">類別</string>
     <string name="unknown">未知</string>
 
-    <string name="channel1_name">下載畫廊</string>
-    <string name="channel2_name">創建PDF</string>
-    <string name="channel1_description">用於顯示畫廊下載進度</string>
-    <string name="channel2_description">用於顯示PDF創建進度</string>
-    <string name="channel2_title">正在創建的PDF：</string>
+    <string name="channel1_name">下載圖庫</string>
+    <string name="channel2_name">建立 PDF</string>
+    <string name="channel1_description">用於顯示圖庫下載進度</string>
+    <string name="channel2_description">用於顯示 PDF 建立進度</string>
+    <string name="channel2_title">正在建立的 PDF：</string>
 
-    <string name="favorite_max_reached" formatted="true">你最多能收藏 %d 部漫畫。</string>
-    <string name="tags_max_reached" formatted="true">你最多能選中 %d 個標籤。</string>
+    <string name="favorite_max_reached" formatted="true">最多只能收藏 %d 部漫畫。</string>
+    <string name="tags_max_reached" formatted="true">最多只能選擇 %d 個標籤。</string>
 
 
     <string name="only_english">僅英文</string>
@@ -52,10 +52,10 @@
     <string name="all_languages">所有語言</string>
 
 
-    <string name="username_or_email">用戶名或郵件</string>
+    <string name="username_or_email">用戶名或電子郵件</string>
     <string name="password">密碼</string>
-    <string name="login">登錄</string>
-    <string name="login_formatted" formatted="true">以 %s 身份登錄</string>
+    <string name="login">登入</string>
+    <string name="login_formatted" formatted="true">以 %s 身份登入</string>
     <string name="logout">登出</string>
     <string name="forgot_password">忘記密碼？<b>重置密碼</b></string>
     <string name="register">沒有帳戶？<b>註冊帳號</b></string>
@@ -71,22 +71,22 @@
 
     <string name="are_you_sure">你確定？</string>
     <string name="thumbnail">預覽</string>
-    <string name="settings">設置</string>
+    <string name="settings">設定</string>
     <string name="related">相關</string>
     <string name="failed">失敗</string>
-    <string name="search">搜索</string>
+    <string name="search">搜尋</string>
     <string name="prev">上一個</string>
     <string name="share">分享</string>
     <string name="image">圖像</string>
     <string name="next">下一個</string>
 
-    <string name="create_pdf">創建PDF</string>
-    <string name="create_pdf_format" formatted="true">創建的PDF："%s"</string>
-	<string name="create_zip_format" formatted="true">創建的ZIP："%s"</string>																			
-    <string name="created_pdf">成功創建PDF</string>
-    <string name="error_pdf">創建PDF出錯</string>
+    <string name="create_pdf">建立 PDF</string>
+    <string name="create_pdf_format" formatted="true">建立的 PDF："%s"</string>
+	<string name="create_zip_format" formatted="true">建立的 ZIP："%s"</string>																			
+    <string name="created_pdf">成功建立 PDF</string>
+    <string name="error_pdf">建立 PDF 出錯</string>
     <string name="parsing_pages">正在分析頁面</string>
-    <string name="writing_pdf">正在寫入PDF</string>
+    <string name="writing_pdf">正在寫入 PDF</string>
 
 											  
     <string name="navigation_drawer_open">打開側邊欄</string>
@@ -98,11 +98,11 @@
     <string name="next_page">下一頁</string>
 
     <string name="downloaded_manga">已下載漫畫</string>
-    <string name="download_gallery">下載畫廊</string>
+    <string name="download_gallery">下載圖庫</string>
     <string name="download_completed">下載完成</string>
 
-    <string name="delete_gallery_size_format" formatted="true">刪除畫廊 (%.2fMB)</string>
-    <string name="delete_gallery_format" formatted="true">是否刪除畫廊：\n%s</string>
+    <string name="delete_gallery_size_format" formatted="true">刪除圖庫 (%.2fMB)</string>
+    <string name="delete_gallery_format" formatted="true">是否刪除圖庫：\n%s</string>
 
 
     <string name="share_with">分享</string>
@@ -114,16 +114,16 @@
     <string name="tag_preference">標籤偏好</string>
     <string name="manage_tags">管理標籤</string>
     <string name="applied_filters">已篩選</string>
-    <string name="show_related">跳轉至相關畫廊</string>
+    <string name="show_related">跳轉至相關漫畫</string>
     <string name="random_manga">隨機漫畫</string>
     <string name="save_page">保存頁數</string>
     <string name="page_count_format" formatted="true">%d 頁</string>
     <string name="upload_date_format" formatted="true">上傳於 %s 在 %s</string>
     <string name="favorite_count_format" formatted="true">%d 收藏</string>
     <string name="favorite_manga">收藏漫畫</string>
-    <string name="setting_on_remove_ignored">不顯示帶有已忽略標籤的畫廊</string>
-    <string name="setting_off_remove_ignored">模糊化帶有已忽略標籤的畫廊</string>
-    <string name="remove_ignored_galleries">移除已忽略畫廊</string>
+    <string name="setting_on_remove_ignored">不顯示帶有已忽略標籤的圖庫</string>
+    <string name="setting_off_remove_ignored">模糊化帶有已忽略標籤的圖庫</string>
+    <string name="remove_ignored_galleries">移除已忽略圖庫</string>
     <string name="clear_tag_preferences">清除標籤偏好</string>
     <string name="check_for_update_on_startup">啟動時檢查更新</string>
     <string name="check_for_updates">檢查更新</string>
@@ -132,51 +132,51 @@
     <string name="new_version_found">發現新版本</string>
     <string name="update_version_format" formatted="true">從V %s 更新至V %s？\n\nChangelog:\n%s</string>
     <string name="clear_this_list">清空此列表？</string>
-    <string name="set_minimum_count">設置最小值</string>
+    <string name="set_minimum_count">設定最小值</string>
     <string name="sort_by_title">按標題排列</string>
     <string name="sort_by_popular">按熱度排列</string>
     <string name="next_page_volume_up">音量+切換下一頁</string>
     <string name="next_page_volume_down">音量-切換下一頁</string>
     <string name="change_title_type">更改標題類型</string>
-    <string name="title_type_summary">為畫廊選擇默認標題類型</string>
+    <string name="title_type_summary">為圖庫選擇默認標題類型</string>
 
-    <string name="search_settings">搜索設置</string>
-    <string name="global_settings">全域設置</string>
-    <string name="images_settings">圖像設置</string>
-    <string name="miscellaneous">其它設置</string>
-    <string name="update_settings">更新設置</string>
+    <string name="search_settings">搜尋設定</string>
+    <string name="global_settings">全域設定</string>
+    <string name="images_settings">圖像設定</string>
+    <string name="miscellaneous">其它設定</string>
+    <string name="update_settings">更新設定</string>
     <string name="online_favorite_manga">線上收藏漫畫</string>
-    <string name="cache_size_formatted">緩存大小：%.2f MB</string>
-    <string name="cache_cleared">緩存已清理</string>
+    <string name="cache_size_formatted">快取大小：%.2f MB</string>
+    <string name="cache_cleared">快取已清理</string>
     <string name="sort_by_latest">按更新排列</string>
     <string name="edit">編輯</string>
     <string name="options">選項</string>
-    <string name="keep_history">保留搜索歷史</string>
-    <string name="add">加入</string>
+    <string name="keep_history">保留搜尋歷史</string>
+    <string name="add">新增</string>
     <string name="insert_tag_name">插入標籤名：</string>
     <string name="favorite_count">收藏數</string>
     <string name="comments">評論</string>
     <string name="send">發送</string>
     <string name="send_comment">發送評論…</string>
     <string name="profile_picture">頭像</string>
-    <string name="send_bug_on_github">在Github上回饋bug</string>
+    <string name="send_bug_on_github">在 Github 上提交錯誤報告</string>
     <string name="github">Github</string>
     <string name="install">安裝</string>
     <string name="download_update_failed">無法下載新版本</string>
     <string name="copyURL">複製URL</string>
-    <string name="add_bookmark">加入書簽</string>
-    <string name="manage_bookmarks">管理書簽</string>
+    <string name="add_bookmark">加入書籤</string>
+    <string name="manage_bookmarks">管理書籤</string>
     <string name="bookmark_page_format">第 %d 頁</string>
-    <string name="bookmark_description">書簽描述</string>
+    <string name="bookmark_description">書籤描述</string>
     <string name="enable_right_to_left">從右至左閱讀</string>
     <string name="setting_on_use_rtl">圖像將從右至左顯示</string>
     <string name="setting_off_use_rtl">圖像將從左至右顯示</string>														
     <string name="volume_change_setting">音量鍵換頁</string>
-    <string name="popular_tag_count">高級搜索中顯示熱門標籤數</string>
-    <string name="show_gallery_titles">顯示畫廊標題</string>
+    <string name="popular_tag_count">進階搜尋中顯示熱門標籤數</string>
+    <string name="show_gallery_titles">顯示圖庫標題</string>
     <string name="change_language">更改語言</string>
 
-    <string name="tag_artist_gallery">藝術家：</string>
+    <string name="tag_artist_gallery">繪師：</string>
     <string name="tag_character_gallery">角色：</string>
     <string name="tag_parody_gallery">原作：</string>
     <string name="tag_language_gallery">語言：</string>
@@ -194,66 +194,66 @@
     <string name="pause_all_downloads">停止所有下載</string>
     <string name="cancel_all_downloads">取消所有下載</string>
     <string name="disable_lock_title">閱讀時常亮</string>
-    <string name="download_all_galleries_in_this_page">下載此頁所有畫廊</string>
-    <string name="download_all_galleries">下載所有畫廊</string>
+    <string name="download_all_galleries_in_this_page">下載此頁所有圖庫</string>
+    <string name="download_all_galleries">下載所有圖庫</string>
 
     <string name="favorite_column_count">選擇收藏介面列數</string>
     <string name="download_column_count">選擇下載介面列數</string>
     <string name="main_column_count">選擇主介面列數</string>
-    <string name="navigation_settings">巡覽列設置</string>
+    <string name="navigation_settings">巡覽列設定</string>
     <string name="stop_download">停止下載</string>
     <string name="start_download">開始下載</string>
-    <string name="create_zip">創建ZIP</string>
-    <string name="channel3_name">創建ZIP</string>
-    <string name="channel3_description">用於顯示zip的創建進度</string>
-    <string name="channel3_title">創建ZIP：</string>
-    <string name="created_zip">成功創建ZIP</string>
-    <string name="failed_zip">創建ZIP失敗: </string>
+    <string name="create_zip">建立 ZIP</string>
+    <string name="channel3_name">建立 ZIP</string>
+    <string name="channel3_description">用於顯示 ZIP 的建立進度</string>
+    <string name="channel3_title">建立 ZIP：</string>
+    <string name="created_zip">成功建立 ZIP</string>
+    <string name="failed_zip">無法建立 ZIP：</string>
     <string name="start_page">起始頁</string>
     <string name="end_page">結束頁</string>
     <string name="invalid_range_selected">選擇的範圍無效</string>
     <string name="column_count_select">列數選擇</string>
     <string name="send_with_title">與標題一起發送？</string>
-    <string name="caption_send_with_title">在圖片上添加URL浮水印？</string>
-    <string name="error_404">錯誤 404: 未找到</string>
-    <string name="history_size">歷史條目數</string>
-    <string name="history_size_summary">設置歷史條目最大值</string>
-    <string name="view_history">閱讀歷史</string>
-    <string name="history">歷史</string>
+    <string name="caption_send_with_title">在圖片上添加 URL 浮水印？</string>
+    <string name="error_404">錯誤 404：未找到網頁</string>
+    <string name="history_size">歷史記錄大小</string>
+    <string name="history_size_summary">設定歷史記錄最大值</string>
+    <string name="view_history">歷史記錄</string>
+    <string name="history">歷史記錄</string>
     <string name="history_column_count">選擇歷史列數</string>
     <string name="clear_history">清除歷史</string>
-    <string name="cancelled_format">取消: %s</string>
-    <string name="completed_format">完成: %s</string>
+    <string name="cancelled_format">取消：%s</string>
+    <string name="completed_format">完成：%s</string>
     <string name="stop">停止</string>
-    <string name="downloading_format">下載中: %s</string>
+    <string name="downloading_format">下載中：%s</string>
     <string name="toggle_favorite">切換收藏</string>
     <string name="resume">恢復</string>
     <string name="pause">暫停</string>
     <string name="title_copied_to_clipboard">標題已複製至剪貼板</string>
-    <string name="setting_zoom_one_column">在畫廊內一列顯示時啟用縮放</string>
+    <string name="setting_zoom_one_column">在圖庫內一列顯示時啟用縮放</string>
     <string name="zoom_one_column">啟用縮放</string>
-    <string name="insert_pin">輸入PIN碼</string>
-    <string name="confirm_pin">確認PIN碼</string>
-    <string name="setting_pin">啟用PIN碼登錄應用</string>
-    <string name="use_pin">使用PIN碼</string>
-    <string name="wrong_pin">PIN碼錯誤</string>
+    <string name="insert_pin">輸入 PIN 碼</string>
+    <string name="confirm_pin">確認 PIN 碼</string>
+    <string name="setting_pin">啟用 PIN 碼登入應用</string>
+    <string name="use_pin">使用 PIN 碼</string>
+    <string name="wrong_pin">PIN 碼錯誤</string>
     <string name="rotate_image">旋轉圖片</string>
-    <string name="setting_alternative">在有審查制度的國家用nhent.ai替代nhentai.net</string>
-    <string name="use_alternative">使用nhent.ai</string>
+    <string name="setting_alternative">在有審查制度的國家使用 nhent.ai 而非 nhentai.net </string>
+    <string name="use_alternative">使用 nhent.ai</string>
     <string name="toggle_online_favorite">切換線上收藏</string>
-    <string name="data_usage_settings">修改資料使用設置</string>
-    <string name="mobile_data_usage_setting">流量使用設置</string>
-    <string name="wifi_data_usage_setting">Wi-Fi使用設置</string>
-    <string name="data_usage_thumb">總是下載縮略圖</string>
-    <string name="data_usage_full">按需下載縮略圖或完整圖片</string>
+    <string name="data_usage_settings">修改資料使用設定</string>
+    <string name="mobile_data_usage_setting">流量使用設定</string>
+    <string name="wifi_data_usage_setting">Wi-Fi 使用設定</string>
+    <string name="data_usage_thumb">總是下載縮圖</string>
+    <string name="data_usage_full">按需下載縮圖或完整圖片</string>
     <string name="data_usage_no">不下載圖片</string>
     <string name="enable_network_to_continue">允許下載圖片或切換網路以打開圖片</string>
     <string name="donate">支援開發者</string>
-    <string name="id_tag">ID:</string>
+    <string name="id_tag">ID：</string>
     <string name="id_copied_to_clipboard">ID已複製至剪貼板</string>
     <string name="copied_to_clipboard">複製至剪貼板</string>
     <string name="maximum_notification_count">最大通知數</string>
-    <string name="copy_settings_to_clipboard">復制設置到剪貼板</string>
+    <string name="copy_settings_to_clipboard">復制設定到剪貼板</string>
     <string name="sort_popular_all_time">熱門</string>
     <string name="sort_recent">最近</string>
     <string name="sort_popular_day">日榜</string>
@@ -268,7 +268,7 @@
     <string name="default_zoom">默認縮放</string>
     <string name="choose_directory">選擇資料夾</string>
     <string name="change_directory_position">更改資料夾路徑</string>
-    <string name="bookmark_here">加入書簽</string>
+    <string name="bookmark_here">加入書籤</string>
     <string name="resume_from_page">從 %d 頁繼續</string>
     <string name="new_beta_version_found">發現新的測試版</string>
     <string name="check_beta_releases">下載測試版</string>
@@ -285,21 +285,22 @@
     <string name="days">日</string>
     <string name="weeks">周</string>
     <string name="choose_unit">選擇時間單位:</string>
-    <string name="change_status">Change status</string>
-    <string name="create_new_status">Create new status:</string>
-    <string name="invalid_color_selected">Black and white can not be used</string>
-    <string name="change_status_title">Select new status:</string>
-    <string name="remove_status">None</string>
-    <string name="name_too_short">Name too short</string>
-    <string name="duplicated_name">Duplicated name</string>
-    <string name="manage_statuses">Manage statuses</string>
-    <string name="update_status">Update status:</string>
-    <string name="view_statuses">View statuses</string>
-    <string name="status_column_count">Select status column count</string>
-    <string name="status_viewer">Status viewer</string>
+    <string name="change_status">變更狀態</string>
+    <string name="create_new_status">建立新狀態：</string>
+    <string name="invalid_color_selected">無法使用黑白顏色</string>
+    <string name="change_status_title">選擇新狀態：</string>
+    <string name="remove_status">無</string>
+    <string name="name_too_short">名稱太短</string>
+    <string name="duplicated_name">名稱重複</string>
+    <string name="manage_statuses">管理狀態</string>
+    <string name="update_status">更新狀態：</string>
+    <string name="view_statuses">漫畫狀態</string>
+    <string name="status_column_count">選擇狀態列數</string>
+    <string name="status_viewer">漫畫狀態</string>
 
 
     <string-array name="language">
+        <item>系統預設</item>
         <item>英文</item>
         <item>繁體中文</item>
         <item>簡體中文</item>
@@ -309,7 +310,7 @@
         <item>阿拉伯</item>
     </string-array>
     <string-array name="theme">
-        <item>亮色</item>
+        <item>淺色</item>
         <item>暗色</item>
     </string-array>
 	

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -4,10 +4,6 @@
     <!--SUMMARY-->
     <string name="setting_on_ignore_tags">從圖庫功能表中選中一個標籤時不再查詢其它標籤（語言項除外）</string>
     <string name="setting_off_ignore_tags">從圖庫功能表中選中一個標籤時查詢其它標籤</string>
-    <string name="setting_on_high_res">載入原圖（更多資料量）</string>
-    <string name="setting_off_high_res">載入縮圖（較少資料量）</string>
-    <string name="setting_on_load">所有活動均載入圖像</string>
-    <string name="setting_off_load">僅單頁閱讀時載入圖像</string>
     <string name="setting_on_use_account_tag">帳戶標籤用於搜尋（本地標籤優先）</string>
     <string name="setting_off_use_account_tag">搜尋時忽略帳戶標籤</string>
     <string name="theme_summary">選擇主題顏色</string>
@@ -16,10 +12,8 @@
     <string name="send_crash_report">發送錯誤報告</string>
     <string name="change_theme">更改主題</string>
     <string name="clear_cache">清除快取</string>
-    <string name="load_images">載入圖像</string>
     <string name="infinite_scroll">無限滾動</string>
     <string name="ignore_tags">忽略其它標籤</string>
-    <string name="high_res_gallery">以最佳解析度載入圖庫圖像</string>
     <string name="use_account_tag">使用帳戶標籤</string>
 
     <string name="title_activity_gallery">圖庫</string>
@@ -52,14 +46,9 @@
     <string name="all_languages">所有語言</string>
 
 
-    <string name="username_or_email">用戶名或電子郵件</string>
-    <string name="password">密碼</string>
     <string name="login">登入</string>
     <string name="login_formatted" formatted="true">以 %s 身份登入</string>
     <string name="logout">登出</string>
-    <string name="forgot_password">忘記密碼？<b>重置密碼</b></string>
-    <string name="register">沒有帳戶？<b>註冊帳號</b></string>
-    <string name="invalid_credentials">無效憑證</string>
 
     <string name="favorite_online_manga">線上收藏漫畫</string>
     <string name="online_tags">線上標籤</string>
@@ -99,7 +88,6 @@
 
     <string name="downloaded_manga">已下載漫畫</string>
     <string name="download_gallery">下載圖庫</string>
-    <string name="download_completed">下載完成</string>
 
     <string name="delete_gallery_size_format" formatted="true">刪除圖庫 (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">是否刪除圖庫：\n%s</string>
@@ -215,7 +203,6 @@
     <string name="column_count_select">列數選擇</string>
     <string name="send_with_title">與標題一起發送？</string>
     <string name="caption_send_with_title">在圖片上添加 URL 浮水印？</string>
-    <string name="error_404">錯誤 404：未找到網頁</string>
     <string name="history_size">歷史記錄大小</string>
     <string name="history_size_summary">設定歷史記錄最大值</string>
     <string name="view_history">歷史記錄</string>
@@ -224,7 +211,6 @@
     <string name="clear_history">清除歷史</string>
     <string name="cancelled_format">取消：%s</string>
     <string name="completed_format">完成：%s</string>
-    <string name="stop">停止</string>
     <string name="downloading_format">下載中：%s</string>
     <string name="toggle_favorite">切換收藏</string>
     <string name="resume">恢復</string>
@@ -261,13 +247,11 @@
     <string name="sort_select_type">選擇排序類型：</string>
     <string name="sort_type_title_format" formatted="true">選擇排序類型（%s）</string>
     <string name="unable_to_connect_to_the_site">無法連接網站</string>
-    <string name="error">錯誤</string>
     <string name="no_entry_found">找不到條目</string>
     <string name="retry">重試</string>
     <string name="folder_location">資料夾位置</string>
     <string name="default_zoom">默認縮放</string>
     <string name="choose_directory">選擇資料夾</string>
-    <string name="change_directory_position">更改資料夾路徑</string>
     <string name="bookmark_here">加入書籤</string>
     <string name="resume_from_page">從 %d 頁繼續</string>
     <string name="new_beta_version_found">發現新的測試版</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,6 +2,7 @@
 
 <resources>
     <!--DO NOT TRANSLATE-->
+    <string name="key_default_value" translatable="false">default_value</string>
     <string name="key_enable_beta" translatable="false">enable_beta</string>
     <string name="key_save_path" translatable="false">save_path</string>
     <string name="key_local_sort" translatable="false">local_sort</string>
@@ -30,6 +31,7 @@
     <string name="key_column_port_stat" translatable="false">column_port_stat</string>
     <string name="key_column_land_stat" translatable="false">column_land_stat</string>
     <string name="key_language" translatable="false">key_language</string>
+    <string name="key_country" translatable="false">key_country</string>
     <string name="key_disable_lock" translatable="false">disable_lock</string>
     <string name="key_max_history_size" translatable="false">max_history_size</string>
     <string name="key_zoom_one_column" translatable="false">zoom_one_column</string>
@@ -330,6 +332,7 @@
     <string name="status_viewer">Status viewer</string>
 
     <string-array name="language">
+        <item>System Default</item>
         <item>English</item>
         <item>Chinese (Traditional)</item>
         <item>Chinese (Simplified)</item>
@@ -340,13 +343,14 @@
     </string-array>
 
     <string-array name="language_data"><!--DO NOT TRANSLATE-->
-        <item>en</item>
-        <item>ch</item>
-        <item>zh</item>
-        <item>tr</item>
-        <item>it</item>
-        <item>de</item>
-        <item>ar</item>
+        <item>@string/key_default_value</item>
+        <item>en-US</item>
+        <item>zh-TW</item>
+        <item>zh-CN</item>
+        <item>tr-TR</item>
+        <item>it-IT</item>
+        <item>de-DE</item>
+        <item>ar-SA</item>
     </string-array>
 
     <string-array name="theme">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,7 +31,6 @@
     <string name="key_column_port_stat" translatable="false">column_port_stat</string>
     <string name="key_column_land_stat" translatable="false">column_land_stat</string>
     <string name="key_language" translatable="false">key_language</string>
-    <string name="key_country" translatable="false">key_country</string>
     <string name="key_disable_lock" translatable="false">disable_lock</string>
     <string name="key_max_history_size" translatable="false">max_history_size</string>
     <string name="key_zoom_one_column" translatable="false">zoom_one_column</string>
@@ -53,7 +52,6 @@
     <string name="app_name" translatable="false">NClientV2</string>
     <string name="page_switcher_placeholder" translatable="false">0/0</string>
     <string name="page_placeholder" translatable="false">999/999</string>
-    <string name="other" translatable="false">other</string>
     <string name="key_favorite_limit" translatable="false">favorite_limit</string>
     <string name="dash" translatable="false">-</string>
     <string name="slash" translatable="false">/</string>
@@ -61,20 +59,14 @@
 
     <string name="setting_on_ignore_tags">Other tags won\'t be queried when a tag is selected from the gallery menu (except language)</string>
     <string name="setting_off_ignore_tags">Other tags will be queried when a tag is selected from the gallery menu</string>
-    <string name="setting_on_high_res">Best resolution images will be loaded (more data)</string>
-    <string name="setting_off_high_res">Thumbnails images will be loaded (less data)</string>
-    <string name="setting_on_load">Images will be loaded in all activities</string>
-    <string name="setting_off_load">Images will be loaded only in single page viewer</string>
     <string name="setting_on_use_account_tag">Use the account tags into the search query (Local tags will have priority)</string>
     <string name="setting_off_use_account_tag">Account tags will be ignored for the query</string>
     <string name="theme_summary">Select theme colors</string>
     <string name="send_crash_report">Send crash report</string>
     <string name="change_theme">Change theme</string>
     <string name="clear_cache">Clear cache</string>
-    <string name="load_images">Load images</string>
     <string name="infinite_scroll">Infinite scroll</string>
     <string name="ignore_tags">Ignore other tags</string>
-    <string name="high_res_gallery">Load image in best resolution into gallery</string>
     <string name="use_account_tag">Use tags from account</string>
     <string name="title_activity_gallery">Gallery</string>
     <string name="title_activity_zoom">Zoom Activity</string>
@@ -102,14 +94,9 @@
     <string name="only_japanese">Only japanese</string>
     <string name="only_chinese">Only chinese</string>
     <string name="all_languages">All languages</string>
-    <string name="username_or_email">Username or Email</string>
-    <string name="password">Password</string>
     <string name="login">Log in</string>
     <string name="login_formatted" formatted="true">Logged as %s</string>
     <string name="logout">Logout</string>
-    <string name="forgot_password">Forgot your password? <b>Reset it</b></string>
-    <string name="register">Don\'t have an account? <b>Register</b></string>
-    <string name="invalid_credentials">Invalid credentials</string>
     <string name="favorite_online_manga">Favorite online manga</string>
     <string name="online_tags">Online tags</string>
     <string name="add_to_online_favorite">Add to online favorites</string>
@@ -141,7 +128,6 @@
     <string name="next_page">Next page</string>
     <string name="downloaded_manga">Downloaded manga</string>
     <string name="download_gallery">Download gallery</string>
-    <string name="download_completed">Download completed</string>
     <string name="delete_gallery_size_format" formatted="true">Delete gallery (%.2fMB)</string>
     <string name="delete_gallery_format" formatted="true">Do you want to delete the gallery:\n%s</string>
     <string name="share_with">Share with</string>
@@ -248,7 +234,6 @@
     <string name="column_count_select">Column count select</string>
     <string name="send_with_title">Send with title?</string>
     <string name="caption_send_with_title">Append url to the image as caption to the image?</string>
-    <string name="error_404">Error 404: not found</string>
     <string name="history_size">History size</string>
     <string name="history_size_summary">Set the max number of entries for the history</string>
     <string name="view_history">View history</string>
@@ -256,7 +241,6 @@
     <string name="clear_history">Clear history</string>
     <string name="cancelled_format">Cancelled: %s</string>
     <string name="completed_format">Completed: %s</string>
-    <string name="stop">Stop</string>
     <string name="downloading_format">Downloading: %s</string>
     <string name="toggle_favorite">Toggle favorite</string>
     <string name="resume">Resume</string>
@@ -294,13 +278,11 @@
     <string name="sort_type_title_format" formatted="true">Choose sort type (%s)</string>
     <string name="sort_select_type">Choose sort type:</string>
     <string name="unable_to_connect_to_the_site">Unable to connect to the site</string>
-    <string name="error">Error</string>
     <string name="no_entry_found">No entries found</string>
     <string name="retry">Retry</string>
     <string name="folder_location">Folder location</string>
     <string name="default_zoom">Default zoom</string>
     <string name="choose_directory">Choose directory</string>
-    <string name="change_directory_position">Change directory position</string>
     <string name="bookmark_here">Bookmark here</string>
     <string name="resume_from_page">Resume from page %d</string>
     <string name="new_beta_version_found">New beta version found</string>

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -3,11 +3,12 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory android:title="@string/global_settings">
         <ListPreference
-            android:defaultValue="en"
+            android:defaultValue="@string/key_default_value"
             android:entries="@array/language"
             android:entryValues="@array/language_data"
             android:key="@string/key_language"
-            android:title="@string/change_language" />
+            android:title="@string/change_language"
+            app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="dark"
             android:entries="@array/theme"


### PR DESCRIPTION
# Summary

This PR implements proper support for localization by adding ISO 639 and ISO 3166 parsing in the `initLanguage` method, as well as properly localizing zh-TW strings.

## Changes

### i18n Support

The code is now written in a way that supports the standard "639-3166" format, per Android localization guidelines and conventions. This means previous `ch` translation (which was actually `zh-Hant`) can now be put under `zh-TW` after manual localization; the same goes for the `zh` language as well, which can now be categorized as `zh-CN`.

The "System Default" option is now the default option for users when they first install the app. When chosen, the app will check whether or not their currently set language is available with corresponding localization strings within the app; if yes, the app will switch to that language; if not, the app will use English.

### Resource Cleanup

Resource strings and redundant code have been removed.