### PR TITLE
Disable crash report by default

### DIFF
--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -207,7 +207,7 @@
             android:title="@string/volume_change_setting"
             app:iconSpaceReserved="false" />
         <SwitchPreferenceCompat
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="@string/key_send_report"
             android:title="@string/send_crash_report"
             app:iconSpaceReserved="false" />


### PR DESCRIPTION
This PR sets the default value for sending crash reports to false.

In F-Droid the app is marked with the anti-feature Tracking because of the default value for crash reports: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/11119

I don't know if a privacy policy for this app is required if this option is turned off by default, but it certainly needs one if it is turned on.