### PR TITLE
Added counts to Status Viewer

### DIFF
--- a/app/src/main/java/com/dar/nclientv2/async/database/Queries.java
+++ b/app/src/main/java/com/dar/nclientv2/async/database/Queries.java
@@ -34,6 +34,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 
@@ -975,6 +976,28 @@ public class Queries {
             String likeFilter = '%' + filter + '%';
             LogUtility.d(query);
             return db.rawQuery(query, new String[]{name, likeFilter, likeFilter, likeFilter});
+        }
+
+        public static HashMap<String, Integer> getCountsPerStatus() {
+            String query = String.format("select %s, count(%s) as count from %s group by %s;",
+                StatusMangaTable.NAME, StatusMangaTable.GALLERY, StatusMangaTable.TABLE_NAME, StatusMangaTable.NAME);
+            LogUtility.d(query);
+
+            Cursor cursor = db.rawQuery(query, null);
+            HashMap<String, Integer> counts = new HashMap<String, Integer>();
+
+            while (cursor.moveToNext()) {
+                try {
+                    String status = cursor.getString(0);
+                    int count = cursor.getInt(1);
+                    counts.put(status, count);
+                } catch (Exception e) {
+                    LogUtility.e(e);
+                }
+            }
+
+            cursor.close();
+            return counts;
         }
 
         public static void removeStatus(String name) {

--- a/app/src/main/java/com/dar/nclientv2/ui/main/SectionsPagerAdapter.java
+++ b/app/src/main/java/com/dar/nclientv2/ui/main/SectionsPagerAdapter.java
@@ -6,8 +6,10 @@ import androidx.fragment.app.Fragment;
 import androidx.viewpager2.adapter.FragmentStateAdapter;
 
 import com.dar.nclientv2.StatusViewerActivity;
+import com.dar.nclientv2.async.database.Queries;
 import com.dar.nclientv2.components.status.StatusManager;
 
+import java.util.HashMap;
 import java.util.List;
 
 /**
@@ -16,16 +18,24 @@ import java.util.List;
  */
 public class SectionsPagerAdapter extends FragmentStateAdapter {
     List<String> statuses;
+    HashMap<String, Integer> counts;
 
     public SectionsPagerAdapter(StatusViewerActivity context) {
         super(context.getSupportFragmentManager(), context.getLifecycle());
         statuses = StatusManager.getNames();
+        counts = Queries.StatusMangaTable.getCountsPerStatus();
     }
-
 
     @Nullable
     public CharSequence getPageTitle(int position) {
-        return statuses.get(position);
+        String status = statuses.get(position);
+        int count = 0;
+
+        if (counts.containsKey(status)) {
+            count = counts.get(status);
+        }
+
+        return String.format("%s - %d", status, count);
     }
 
     @NonNull


### PR DESCRIPTION
**Summary**
Added counts next to the status name in the Manage statuses screeen.
![image](https://user-images.githubusercontent.com/19249905/202878923-5ac96bd8-6247-4436-a58e-dfdcc5c7af90.png)

**Motivation**
I think it makes sense to be able to quickly see how many entries have are in each status. (also, Tachiyomi does it)

**Test plan**
It seems to work OK, the only issue I've found so far is that the numbers don't update if you don't exit Status Viewer. (I'm not sure how to fix it)
https://user-images.githubusercontent.com/19249905/202879281-16a1b352-fe05-49ef-919d-0bc2e8649da4.mp4
