### PR TITLE
fix crash, webp support

### DIFF
--- a/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
+++ b/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
@@ -80,7 +80,8 @@ public class SimpleGallery extends GenericGallery {
         a = e.getElementsByTag("img").first();
         temp = a.hasAttr("data-src") ? a.attr("data-src") : a.attr("src");
         mediaId = Integer.parseInt(temp.substring(temp.indexOf("galleries") + 10, temp.lastIndexOf('/')));
-        thumbnail = Page.charToExt(temp.charAt(temp.length() - 3));
+        String extension = temp.substring(temp.lastIndexOf('.') + 1);
+        thumbnail = Page.charToExt(extension.charAt(0));//thumbnail = Page.charToExt(temp.charAt(temp.length() - 3));
         title = e.getElementsByTag("div").first().text();
         if (context != null && id > Global.getMaxId()) Global.updateMaxId(context, id);
     }
@@ -93,6 +94,10 @@ public class SimpleGallery extends GenericGallery {
     }
 
     private static String extToString(ImageExt ext) {
+        //just in case
+        if (ext == null) {
+            return null;
+        }
         switch (ext) {
             case GIF:
                 return "gif";
@@ -100,6 +105,8 @@ public class SimpleGallery extends GenericGallery {
                 return "png";
             case JPG:
                 return "jpg";
+            case WEBP:
+                return "webp";
         }
         return null;
     }

--- a/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
+++ b/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
@@ -79,6 +79,7 @@ public class SimpleGallery extends GenericGallery {
         id = Integer.parseInt(temp.substring(3, temp.length() - 1));
         a = e.getElementsByTag("img").first();
         temp = a.hasAttr("data-src") ? a.attr("data-src") : a.attr("src");
+        //temp = a.attr("src");
         mediaId = Integer.parseInt(temp.substring(temp.indexOf("galleries") + 10, temp.lastIndexOf('/')));
         String extension = temp.substring(temp.lastIndexOf('.') + 1);
         thumbnail = Page.charToExt(extension.charAt(0));//thumbnail = Page.charToExt(temp.charAt(temp.length() - 3));
@@ -178,9 +179,9 @@ public class SimpleGallery extends GenericGallery {
 
     public Uri getThumbnail() {
         if (thumbnail == ImageExt.GIF) {
-            return Uri.parse(String.format(Locale.US, "https://i." + Utility.getHost() + "/galleries/%d/1.gif", mediaId));
+            return Uri.parse(String.format(Locale.US, "https://i1." + Utility.getHost() + "/galleries/%d/1.gif", mediaId));
         }
-        return Uri.parse(String.format(Locale.US, "https://t." + Utility.getHost() + "/galleries/%d/thumb.%s", mediaId, extToString(thumbnail)));
+        return Uri.parse(String.format(Locale.US, "https://t1." + Utility.getHost() + "/galleries/%d/thumb.%s", mediaId, extToString(thumbnail)));
     }
 
     public int getMediaId() {

--- a/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
+++ b/app/src/main/java/com/dar/nclientv2/api/SimpleGallery.java
@@ -81,6 +81,9 @@ public class SimpleGallery extends GenericGallery {
         temp = a.hasAttr("data-src") ? a.attr("data-src") : a.attr("src");
         //temp = a.attr("src");
         mediaId = Integer.parseInt(temp.substring(temp.indexOf("galleries") + 10, temp.lastIndexOf('/')));
+        if (temp.endsWith(".jpg.webp")) {
+            temp = temp.substring(0, temp.length() - 5); // Quita ".webp"
+        }
         String extension = temp.substring(temp.lastIndexOf('.') + 1);
         thumbnail = Page.charToExt(extension.charAt(0));//thumbnail = Page.charToExt(temp.charAt(temp.length() - 3));
         title = e.getElementsByTag("div").first().text();

--- a/app/src/main/java/com/dar/nclientv2/api/comments/User.java
+++ b/app/src/main/java/com/dar/nclientv2/api/comments/User.java
@@ -70,7 +70,7 @@ public class User implements Parcelable {
     }
 
     public Uri getAvatarUrl() {
-        return Uri.parse(String.format(Locale.US, "https://i.%s/%s", Utility.getHost(), avatarUrl));
+        return Uri.parse(String.format(Locale.US, "https://i1.%s/%s", Utility.getHost(), avatarUrl));
     }
 
     public String getUsername() {

--- a/app/src/main/java/com/dar/nclientv2/api/components/Gallery.java
+++ b/app/src/main/java/com/dar/nclientv2/api/components/Gallery.java
@@ -155,7 +155,7 @@ public class Gallery extends GenericGallery {
     public Uri getCover() {
         if (Global.getDownloadPolicy() == Global.DataUsageType.THUMBNAIL) return getThumbnail();
         if (galleryData.getCover().getImageExt() == ImageExt.GIF) return getHighPage(0);
-        return Uri.parse(String.format(Locale.US, "https://t." + Utility.getHost() + "/galleries/%d/cover.%s", getMediaId(), galleryData.getCover().extToString()));
+        return Uri.parse(String.format(Locale.US, "https://t1." + Utility.getHost() + "/galleries/%d/cover.%s", getMediaId(), galleryData.getCover().extToString()));
     }
 
     public ImageExt getThumb() {
@@ -164,7 +164,7 @@ public class Gallery extends GenericGallery {
 
     public Uri getThumbnail() {
         if (galleryData.getCover().getImageExt() == ImageExt.GIF) return getHighPage(0);
-        return Uri.parse(String.format(Locale.US, "https://t." + Utility.getHost() + "/galleries/%d/thumb.%s", getMediaId(), galleryData.getThumbnail().extToString()));
+        return Uri.parse(String.format(Locale.US, "https://t1." + Utility.getHost() + "/galleries/%d/thumb.%s", getMediaId(), galleryData.getThumbnail().extToString()));
     }
 
     private @Nullable
@@ -183,13 +183,13 @@ public class Gallery extends GenericGallery {
     }
 
     public Uri getHighPage(int page) {
-        return Uri.parse(String.format(Locale.US, "https://i." + Utility.getHost() + "/galleries/%d/%d.%s", getMediaId(), page + 1, getPageExtension(page)));
+        return Uri.parse(String.format(Locale.US, "https://i1." + Utility.getHost() + "/galleries/%d/%d.%s", getMediaId(), page + 1, getPageExtension(page)));
     }
 
     public Uri getLowPage(int page) {
         Uri uri = getFileUri(page);
         if (uri != null) return uri;
-        return Uri.parse(String.format(Locale.US, "https://t." + Utility.getHost() + "/galleries/%d/%dt.%s", getMediaId(), page + 1, getPageExtension(page)));
+        return Uri.parse(String.format(Locale.US, "https://t1." + Utility.getHost() + "/galleries/%d/%dt.%s", getMediaId(), page + 1, getPageExtension(page)));
     }
 
     public String getPageExtension(int page) {

--- a/app/src/main/java/com/dar/nclientv2/api/components/GalleryData.java
+++ b/app/src/main/java/com/dar/nclientv2/api/components/GalleryData.java
@@ -315,6 +315,7 @@ public class GalleryData implements Parcelable {
                 case 'p':
                 case 'j':
                 case 'g':
+                case 'w':
                     if (specialImages) {
                         cover = new Page(ImageType.COVER, Page.charToExt(actualChar));
                         thumbnail = new Page(ImageType.THUMBNAIL, Page.charToExt(actualChar));

--- a/app/src/main/java/com/dar/nclientv2/api/components/GalleryData.java
+++ b/app/src/main/java/com/dar/nclientv2/api/components/GalleryData.java
@@ -305,12 +305,12 @@ public class GalleryData implements Parcelable {
 
     private void readPagePath(String path) throws IOException {
         System.out.println(path);
-        StringReader reader = new StringReader(path + "e");//flag for the end
+        StringReader reader = new StringReader(path + "*");//flag for the end
         int absolutePage = 0;
         int actualChar;
         int pageOfType = 0;
         boolean specialImages = true;//compability variable
-        while ((actualChar = reader.read()) != 'e') {
+        while ((actualChar = reader.read()) != '*') {
             switch (actualChar) {
                 case 'p':
                 case 'j':

--- a/app/src/main/java/com/dar/nclientv2/api/components/Page.java
+++ b/app/src/main/java/com/dar/nclientv2/api/components/Page.java
@@ -90,6 +90,8 @@ public class Page implements Parcelable {
                 return "png";
             case JPG:
                 return "jpg";
+            case WEBP:
+                return "webp";
         }
         return null;
     }
@@ -102,6 +104,8 @@ public class Page implements Parcelable {
                 return 'p';
             case JPG:
                 return 'j';
+            case WEBP:
+                return 'w';
         }
         return '\0';
     }
@@ -114,6 +118,8 @@ public class Page implements Parcelable {
                 return ImageExt.PNG;
             case 'j':
                 return ImageExt.JPG;
+            case 'w':
+                return ImageExt.WEBP;
         }
         return null;
     }

--- a/app/src/main/java/com/dar/nclientv2/api/enums/ImageExt.java
+++ b/app/src/main/java/com/dar/nclientv2/api/enums/ImageExt.java
@@ -1,7 +1,7 @@
 package com.dar.nclientv2.api.enums;
 
 public enum ImageExt {
-    JPG("jpg"), PNG("png"), GIF("gif");
+    JPG("jpg"), PNG("png"), GIF("gif"), WEBP("webp");
 
     private final char firstLetter;
     private final String name;

--- a/app/src/main/java/com/dar/nclientv2/api/local/LocalGallery.java
+++ b/app/src/main/java/com/dar/nclientv2/api/local/LocalGallery.java
@@ -34,7 +34,7 @@ public class LocalGallery extends GenericGallery {
             return new LocalGallery[size];
         }
     };
-    private static final Pattern FILE_PATTERN = Pattern.compile("^(\\d{1,9})\\.(gif|png|jpg)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern FILE_PATTERN = Pattern.compile("^(\\d{1,9})\\.(gif|png|jpg|webp)$", Pattern.CASE_INSENSITIVE);
     private static final Pattern DUP_PATTERN = Pattern.compile("^(.*)\\.DUP\\d+$");
     private static final Pattern IDFILE_PATTERN = Pattern.compile("^\\.\\d{1,6}$");
     private final GalleryFolder folder;
@@ -106,6 +106,8 @@ public class LocalGallery extends GenericGallery {
         if (dir == null || !dir.exists()) return null;
         String pag = String.format(Locale.US, "%03d.", page);
         File x;
+        x = new File(dir, pag + "webp");
+        if (x.exists()) return x;
         x = new File(dir, pag + "jpg");
         if (x.exists()) return x;
         x = new File(dir, pag + "png");

--- a/app/src/main/java/com/dar/nclientv2/files/GalleryFolder.java
+++ b/app/src/main/java/com/dar/nclientv2/files/GalleryFolder.java
@@ -32,7 +32,7 @@ public class GalleryFolder implements Parcelable, Iterable<PageFile> {
             return new GalleryFolder[size];
         }
     };
-    private static final Pattern FILE_PATTERN = Pattern.compile("^0*(\\d{1,9})\\.(gif|png|jpg)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern FILE_PATTERN = Pattern.compile("^0*(\\d{1,9})\\.(gif|png|jpg|webp)$", Pattern.CASE_INSENSITIVE);
     private static final Pattern IDFILE_PATTERN = Pattern.compile("^\\.(\\d{1,6})$");
     private static final String NOMEDIA_FILE = ".nomedia";
     private final SparseArrayCompat<PageFile> pageArray = new SparseArrayCompat<>();

--- a/app/src/main/java/com/dar/nclientv2/files/PageFile.java
+++ b/app/src/main/java/com/dar/nclientv2/files/PageFile.java
@@ -28,8 +28,8 @@ public class PageFile extends File implements Parcelable {
             return new PageFile[size];
         }
     };
-    private static final Pattern DEFAULT_THUMBNAIL = Pattern.compile("^0*1\\.(gif|png|jpg)$", Pattern.CASE_INSENSITIVE);
-    private static final Pattern VALID_PAGE = Pattern.compile("^0*(\\d+)\\.(gif|png|jpg)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DEFAULT_THUMBNAIL = Pattern.compile("^0*1\\.(gif|png|jpg|webp)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern VALID_PAGE = Pattern.compile("^0*(\\d+)\\.(gif|png|jpg|webp)$", Pattern.CASE_INSENSITIVE);
     private final ImageExt ext;
     private final int page;
 


### PR DESCRIPTION
Simple code to support .webp format
Download and install: 8/12/24
[app-debug.zip](https://github.com/user-attachments/files/19163410/app-debug.zip)
 to fix the issue temporary 
<img width= 200 src="https://github.com/user-attachments/assets/36c74bd6-ecd5-4cd0-8bd6-c5231636abb6"><br>

Thanks to #756 
It is an interesting application. 
I only have Notepad++, so I work with that.
you just need to add one more extension WEBP("webp")
but the app is programmed to work with extensions of 3 characters jpg png gif, 
webp has 4 characters so I just touched the part that arbitrarily takes the final 3 characters for something more flexible and then you just have to modify the regex, with which you search the files 
and the functions that converted the extension into a character and the character into an extension
simply follow the functions from the inside out

